### PR TITLE
Escape double quote in s:undo_ftplugin_add call

### DIFF
--- a/autoload/sexp/filetype.vim
+++ b/autoload/sexp/filetype.vim
@@ -427,7 +427,7 @@ function! s:sexp_create_mappings() abort
     imap <silent><buffer> }    <Plug>(sexp_insert_closing_curly)
     imap <silent><buffer> "    <Plug>(sexp_insert_double_quote)
     imap <silent><buffer> <BS> <Plug>(sexp_insert_backspace)
-    for lhs in ['(', '[', '{', ')', ']', '}', '"', '<BS>' ]
+    for lhs in ['(', '[', '{', ')', ']', '}', '\"', '<BS>' ]
       call s:undo_ftplugin_add('execute "silent! iunmap <buffer> '.lhs.'"')
     endfor
   endif


### PR DESCRIPTION
Without this, LoadFTPlugin blows up, ala `:verbose function <SNR>12_LoadFTPlugin`

Example of end of `echo b:undo_ftplugin` containing this escape, and why it's needed:

```
|execute "silent! iunmap <buffer> }"
|execute "silent! iunmap <buffer> \""
|execute "silent! iunmap <buffer> <BS>"
```

(but I'm equally curious why this hasn't blown up on you, heh)